### PR TITLE
Fix typo in npm install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ install
 ============
 
 ```sh
-npm instqll -g vimdebug
+npm install -g vimdebug
 ```
 
 use


### PR DESCRIPTION
Install instructions had erronious "npm instqll" command.  Corrected to allow for easy copy/paste for users.
