### PR TITLE
Adds configurable key bindings using rc.

### DIFF
--- a/bin/vim-inspector.js
+++ b/bin/vim-inspector.js
@@ -1,4 +1,20 @@
 #!/usr/bin/env node
+var conf = require('rc')("vimdebug", {
+  vim: {
+    keys: {
+      break    : "C-p",
+      continue : "C-c",
+      down     : "C-d",
+      in       : "C-i",
+      next     : "C-n",
+      out      : "C-o",
+      up       : "C-u"
+    },
+  },
+  agent: {
+    port: 3219
+  }
+});
 
 var portfinder = require('portfinder')
 var spawn = require('child_process').spawn;
@@ -13,7 +29,7 @@ var Repl       = require('../lib/repl.js');
 
 var dc = new Debugger.Client();
 // TODO: handle multiple ports, assign first available starting from 3219
-var agent  = new NBAgent(3219);
+var agent  = new NBAgent(conf);
 
 if (argv._.length != 0) {
   // we need to spawn process

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -3,9 +3,10 @@ var VimConnection = require('./vim-connection.js');
 var util          = require('util');
 var EventEmitter  = require('events').EventEmitter;
 
-function Agent(port) {
+function Agent(conf) {
   EventEmitter.call(this);
-  this.netbeansPort = port;
+  this.conf = conf;
+  this.netbeansPort = conf.agent.port;
   this.nbServer = new VimServer({port: this.netbeansPort});
   this.nbServer.listen();
   this.debuggers = [];

--- a/lib/vim-connection.js
+++ b/lib/vim-connection.js
@@ -16,6 +16,8 @@ tmp.setGracefulCleanup();
 function VimConnection(vim, agent) {
   EventEmitter.call(this);
   this.agent = agent;
+  this.conf = this.agent.conf.vim;
+  this.keys = this.conf.keys;
   this.views = {};                   // key: debuggerId:scriptId
   this.bufferToView = {};
   var currentLineMarker;             // TODO: sould it be debugger propery?
@@ -38,17 +40,17 @@ VimConnection.prototype.addKeyBindings = function() {
       view.dc.step(type, 1, nop);
     };
   }
-  this.vim.key("C-n", stepHandlerFor('next'));
-  this.vim.key("C-i", stepHandlerFor('in'));
-  this.vim.key("C-o", stepHandlerFor('out'));
+  this.vim.key(this.keys.next, stepHandlerFor('next'));
+  this.vim.key(this.keys.in, stepHandlerFor('in'));
+  this.vim.key(this.keys.out, stepHandlerFor('out'));
 
-  this.vim.key("C-c", function (buffer, offset, lnum, col) {
+  this.vim.key(this.keys.continue, function (buffer, offset, lnum, col) {
     var view = self.bufferToView[buffer.id];
     view.dc.reqContinue(nop);
   });
 
   // TODO: refactor
-  this.vim.key("C-u", function (buffer, offset, lnum, col) {
+  this.vim.key(this.keys.up, function (buffer, offset, lnum, col) {
     var view = self.bufferToView[buffer.id];
     var dc = view.dc;
     dc.reqBacktrace(function(err, res) {
@@ -62,7 +64,7 @@ VimConnection.prototype.addKeyBindings = function() {
       self.showScript(dc, scriptRef, frame.line + 1, frame.column);
     });
   });
-  this.vim.key("C-d", function (buffer, offset, lnum, col) {
+  this.vim.key(this.keys.down, function (buffer, offset, lnum, col) {
     var view = self.bufferToView[buffer.id];
     var dc = view.dc;
     dc.reqBacktrace(function(err, res) {
@@ -74,7 +76,7 @@ VimConnection.prototype.addKeyBindings = function() {
       self.showScript(dc, scriptRef, frame.line + 1, frame.column);
     });
   });
-  this.vim.key("C-j", function (buffer, offset, lnum, col) {
+  this.vim.key(this.keys.jump, function (buffer, offset, lnum, col) {
     var view = self.bufferToView[buffer.id];
     var dc = view.dc;
     dc.reqBacktrace(function(err, res) {
@@ -84,7 +86,7 @@ VimConnection.prototype.addKeyBindings = function() {
       self.showScript(dc, scriptRef, res.frames[dc.currentFrame].line + 1, 0);
     });
   });
-  this.vim.key("C-p", function (buffer, offset, lnum, col) {
+  this.vim.key(this.keys.break, function (buffer, offset, lnum, col) {
     // TODO:
     var line = parseInt(lnum, 10);
     var column = parseInt(col, 10);
@@ -109,7 +111,7 @@ VimConnection.prototype.addKeyBindings = function() {
       view.addBreakpointMarker(pos);
     })
   });
-  this.vim.key("C-f", function (buffer, offset, lnum, col) {
+  this.vim.key(this.keys.toggle, function (buffer, offset, lnum, col) {
     var view = self.bufferToView[buffer.id];
     //var script = view.dc.scripts[view.scriptId];
     //self.showScript(dc, script, line, column);

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "convert-source-map": "^0.4.1",
     "optimist": "^0.6.1",
     "portfinder": "^0.2.1",
+    "rc": "^0.5.1",
     "source-map": "~0.1.25",
     "tmp": "0.0.20",
     "v8-debugger": "0.0.3",


### PR DESCRIPTION
See [documentation](https://github.com/dominictarr/rc)

The appname is 'vimdebug' and key bindings are under vim.keys.<command>, e.g.:
`vim.keys.break`.

For example, to configure the add-breakpoint key to <Ctrl-b>

`./lib/vim-inspector.js --vim.keys.break="C-b"`

or a `~/.vimdebugrc` containing:

``` json
{
  "vim": {
    "keys": {
      "break": "C-b"
    }
  }
  // vim: set ft=json:
}
```

Closes #13.
